### PR TITLE
Call (spray-quit) instead of (spray-mode -1)

### DIFF
--- a/spray.el
+++ b/spray.el
@@ -270,7 +270,7 @@ decreasing by one for each subsequent word."
         (t
          (widen)
          (if (eobp)
-             (spray-mode -1)
+             (spray-quit)
            (when (not (zerop spray--first-words))
              (setq spray--initial-delay spray--first-words)
              (setq spray--first-words (1- spray--first-words)))


### PR DESCRIPTION
Hi Ian,

This PR replaces the call to `(spray-mode -1)` by `(spray-quit)`.
This make it easier to advice spray when it quits.

Cheers,
syl20bnr